### PR TITLE
Add options to use aerobraking to reach elliptical orbit and low orbit

### DIFF
--- a/src/app/components/panel/panel.component.html
+++ b/src/app/components/panel/panel.component.html
@@ -106,6 +106,30 @@
       <div class="form-check">
         <input class="form-check-input"
                type="checkbox"
+               id="aeroCaptureEllipticalCheck"
+               (change)="astroPathService.pathChanged(path)"
+               [(ngModel)]="path.aeroCaptureElliptical">
+        <label class="form-check-label" for="aeroCaptureEllipticalCheck">
+          Aero Capture (Elliptical)
+        </label>
+      </div>
+    </div>
+    <div class="mx-2">
+      <div class="form-check">
+        <input class="form-check-input"
+               type="checkbox"
+               id="aeroCaptureLowCheck"
+               (change)="astroPathService.pathChanged(path)"
+               [(ngModel)]="path.aeroCaptureLow">
+        <label class="form-check-label" for="aeroCaptureLowCheck">
+          Aero Capture (Low)
+        </label>
+      </div>
+    </div>
+    <div class="mx-2">
+      <div class="form-check">
+        <input class="form-check-input"
+               type="checkbox"
                id="aerobrakingCheck"
                (change)="astroPathService.pathChanged(path)"
                [(ngModel)]="path.aerobraking">
@@ -148,7 +172,15 @@
           <i class="fas fa-cloud-download-alt mr-2"></i>
           <ksp-dv-pill [step]="step"></ksp-dv-pill>
         </div>
-        <div *ngIf="!landingInAtmosphere(step)"
+        <div *ngIf="capturingInAtmosphere(step)"
+             class="badge badge-secondary badge-dv"
+             ngbPopover="Aerobraking is possible"
+             triggers="mouseenter:mouseleave"
+             placement="top-right">
+          <i class="fas fa-cloud-download-alt mr-2"></i>
+          <ksp-dv-pill [step]="step"></ksp-dv-pill>
+        </div>
+        <div *ngIf="!landingInAtmosphere(step) && !capturingInAtmosphere(step)"
              class="badge badge-secondary badge-dv">
           <ksp-dv-pill [step]="step"></ksp-dv-pill>
         </div>

--- a/src/app/components/panel/panel.component.ts
+++ b/src/app/components/panel/panel.component.ts
@@ -70,4 +70,10 @@ export class PanelComponent implements OnInit, OnDestroy {
     return step.type === StepType.landing && this.path.to.hasAtmosphere;
   }
 
+  capturingInAtmosphere(step: Step): boolean {
+    return step.type === StepType.transitToLowOrbit &&
+      step.to?.hasAtmosphere &&
+      (this.path.aeroCaptureLow || this.path.aeroCaptureElliptical);
+  }
+
 }

--- a/src/app/models/planet.model.ts
+++ b/src/app/models/planet.model.ts
@@ -7,6 +7,8 @@ export interface AstroPath {
   to: AstroBody;
   landing: boolean;
   aerobraking: boolean;
+  aeroCaptureLow: boolean;
+  aeroCaptureElliptical: boolean;
   steps: Step[];
   total: Step;
   return: boolean;

--- a/src/app/services/astro-path.service.ts
+++ b/src/app/services/astro-path.service.ts
@@ -19,6 +19,8 @@ export class AstroPathService {
       to: null,
       landing: false,
       aerobraking: true,
+      aeroCaptureLow: false,
+      aeroCaptureElliptical: false,
       steps: [],
       total: null,
       return: false
@@ -138,7 +140,12 @@ export class AstroPathService {
 
   private computeKerbinToPlanet(path: AstroPath): void {
     const planet = path.to as Planet;
-    const dv = this.kerbin.transitToLowOrbit(planet);
+    let dv = this.kerbin.transitToLowOrbit(planet);
+    if (path.aeroCaptureLow && planet.hasAtmosphere) {
+      dv -= (planet.dvLI || planet.dvLE + (planet.dvEI || 0));
+    } else if (path.aeroCaptureElliptical && planet.hasAtmosphere) {
+      dv -= (planet.dvEI || 0);
+    }
     path.steps.push({
       type: StepType.transitToLowOrbit,
       to: path.to,
@@ -149,7 +156,12 @@ export class AstroPathService {
 
   private computePlanetToKerbin(path: AstroPath): void {
     const planet = path.from as Planet;
-    const dv = this.kerbin.transitToLowOrbit(planet);
+    let dv = this.kerbin.transitToLowOrbit(planet);
+    if (path.aeroCaptureLow && this.kerbin.hasAtmosphere) {
+      dv -= (this.kerbin.dvLE + (planet.dvK || 0));
+    } else if (path.aeroCaptureElliptical && this.kerbin.hasAtmosphere) {
+      dv -= (planet.dvK || 0);
+    }
     path.steps.push({
       type: StepType.transitToLowOrbit,
       to: this.kerbin,


### PR DESCRIPTION
Adds two new checkboxes "Aero Capture (Elliptical)" and "Aero Capture (Low)" to the planner panel. When selected, the transit step delta-V calculation subtracts the appropriate orbital insertion burn delta-V for bodies with an atmosphere. Includes corresponding UI badge indicator for transit steps where aerocapture is applied.

---
*PR created automatically by Jules for task [17011957680067768158](https://jules.google.com/task/17011957680067768158) started by @LoicViennois*