### PR TITLE
🧪 Add test coverage for `isKerbinTrip` getter in AstroPathService

### DIFF
--- a/src/app/services/astro-path.service.spec.ts
+++ b/src/app/services/astro-path.service.spec.ts
@@ -1,0 +1,77 @@
+import { TestBed } from '@angular/core/testing';
+import { AstroPathService } from './astro-path.service';
+import { BodiesService } from './bodies.service';
+import { AstroBody } from '../models/planet.model';
+
+describe('AstroPathService', () => {
+  let service: AstroPathService;
+  let bodiesService: BodiesService;
+  let kerbin: AstroBody;
+  let eve: AstroBody;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AstroPathService, BodiesService],
+    });
+    service = TestBed.inject(AstroPathService);
+    bodiesService = TestBed.inject(BodiesService);
+    kerbin = bodiesService.bodies.find(b => b.name === 'Kerbin')!;
+    eve = bodiesService.bodies.find(b => b.name === 'Eve')!;
+  });
+
+  describe('isKerbinTrip', () => {
+    it('should return false when "to" is null', () => {
+      service.pathChanged({
+        ...service.path(),
+        from: kerbin,
+        to: null
+      });
+      expect(service.isKerbinTrip()).toBe(false);
+    });
+
+    it('should return false when "from" is null', () => {
+      service.pathChanged({
+        ...service.path(),
+        from: null,
+        to: kerbin
+      });
+      expect(service.isKerbinTrip()).toBe(false);
+    });
+
+    it('should return true when both "from" and "to" are Kerbin', () => {
+      service.pathChanged({
+        ...service.path(),
+        from: kerbin,
+        to: kerbin
+      });
+      expect(service.isKerbinTrip()).toBe(true);
+    });
+
+    it('should return false when "from" is Kerbin and "to" is not Kerbin', () => {
+      service.pathChanged({
+        ...service.path(),
+        from: kerbin,
+        to: eve
+      });
+      expect(service.isKerbinTrip()).toBe(false);
+    });
+
+    it('should return false when "from" is not Kerbin and "to" is Kerbin', () => {
+      service.pathChanged({
+        ...service.path(),
+        from: eve,
+        to: kerbin
+      });
+      expect(service.isKerbinTrip()).toBe(false);
+    });
+
+    it('should return false when both "from" and "to" are not Kerbin', () => {
+      service.pathChanged({
+        ...service.path(),
+        from: eve,
+        to: eve
+      });
+      expect(service.isKerbinTrip()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `isKerbinTrip` computed property in `AstroPathService` was previously untested, leaving potential for regressions when refactoring path logic.

📊 **Coverage:** What scenarios are now tested
- Edge cases with `null` origins or destinations.
- Happy path where both `from` and `to` are `Kerbin`.
- Negative scenarios where either `from`, `to`, or both are not `Kerbin`.

✨ **Result:** The improvement in test coverage
The computed property is now fully tested with an isolated test suite, improving maintainability and ensuring safe refactoring.

---
*PR created automatically by Jules for task [13058337891882172799](https://jules.google.com/task/13058337891882172799) started by @LoicViennois*