### PR TITLE
🧪 test(panel): add unit tests for PanelComponent.pathFromChanged

### DIFF
--- a/src/app/components/panel/panel.component.spec.ts
+++ b/src/app/components/panel/panel.component.spec.ts
@@ -1,0 +1,61 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import { PanelComponent } from './panel.component';
+import { AstroPathService } from '../../services/astro-path.service';
+import { BodiesService } from '../../services/bodies.service';
+
+describe('PanelComponent', () => {
+  let component: PanelComponent;
+  let astroPathService: AstroPathService;
+  let bodiesService: BodiesService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PanelComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(PanelComponent);
+    component = fixture.componentInstance;
+    astroPathService = TestBed.inject(AstroPathService);
+    bodiesService = TestBed.inject(BodiesService);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('pathFromChanged', () => {
+    it('should update path.from and set path.to to Kerbin when body is not Kerbin', () => {
+      const dunaBody = bodiesService.bodies.find((b) => b.name === 'Duna')!;
+      const spy = vi.spyOn(astroPathService, 'pathChanged');
+
+      component.pathFromChanged(dunaBody);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: dunaBody,
+          to: bodiesService.kerbin,
+        })
+      );
+    });
+
+    it('should update path.from to Kerbin and keep path.to unchanged when body is Kerbin', () => {
+      const dunaBody = bodiesService.bodies.find((b) => b.name === 'Duna')!;
+      astroPathService.pathChanged({ ...astroPathService.path(), to: dunaBody });
+
+      const kerbinBody = bodiesService.kerbin;
+      const spy = vi.spyOn(astroPathService, 'pathChanged');
+
+      component.pathFromChanged(kerbinBody);
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: kerbinBody,
+          to: dunaBody,
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:**
Added unit tests for the `pathFromChanged` method in `PanelComponent` (`src/app/components/panel/panel.component.spec.ts`).

📊 **Coverage:**
- Changing origin body (`pathFrom`) to a non-Kerbin body (e.g. Duna), verifying `path.from` is updated, `path.to` is reset to Kerbin, and `astroPathService.pathChanged` is called.
- Changing origin body (`pathFrom`) to Kerbin, verifying `path.from` is updated to Kerbin, `path.to` remains unchanged, and `astroPathService.pathChanged` is called.

✨ **Result:**
Improved test coverage and reliability for `PanelComponent`.

---
*PR created automatically by Jules for task [16042444228674492456](https://jules.google.com/task/16042444228674492456) started by @LoicViennois*